### PR TITLE
Modifiche varie

### DIFF
--- a/pySIC.py
+++ b/pySIC.py
@@ -11,22 +11,22 @@ nameDoc = ""
 
 ###########################################################
 
-def readmerge(name, dir, lang = "", debug = False):
+def readmerge(name, lang = "", debug = False):
     global phase
     global nameDoc
     nameDoc = name
-    app_folder = os.path.dirname(dir)
+    app_folder = os.path.dirname(os.getcwd())
     fi = os.path.join(app_folder, "data")
     fo = os.path.join(app_folder, "output", "out_cropper")
     phase = 1
     merger.merge(fi, fo, name + ".pdf", debug)
     phase = 0
    
-def elaborate(name, dir, ocr = False, lang = "", debug = False):
+def elaborate(name, ocr = False, lang = "", debug = False):
     global phase
     global nameDoc
     nameDoc = name
-    app_folder = os.path.dirname(dir)
+    app_folder = os.path.dirname(os.getcwd())
     fi = os.path.join(app_folder, "data")
     fo = os.path.join(app_folder, "output", "out_cropper")
     phase = 1
@@ -48,7 +48,7 @@ def elaborate(name, dir, ocr = False, lang = "", debug = False):
     
 def reset(delData = False, delPdf = {"general": False, "reader": False, "maker": False}):
     if delPdf["general"]:
-        dr = os.path.dirname(__file__)
+        dr = os.path.dirname(os.getcwd())
         for d in os.listdir("."):
             if d.endswith(".pdf"):
                 os.remove(os.path.join(dr, d))

--- a/pySIC.py
+++ b/pySIC.py
@@ -22,11 +22,11 @@ def readmerge(name, dir, lang = "", debug = False):
     merger.merge(fi, fo, name + ".pdf", debug)
     phase = 0
    
-def elaborate(name, ocr = False, lang = "", debug = False):
+def elaborate(name, dir, ocr = False, lang = "", debug = False):
     global phase
     global nameDoc
     nameDoc = name
-    app_folder = os.path.dirname(__file__)
+    app_folder = os.path.dirname(dir)
     fi = os.path.join(app_folder, "data")
     fo = os.path.join(app_folder, "output", "out_cropper")
     phase = 1

--- a/pySIC.py
+++ b/pySIC.py
@@ -11,11 +11,11 @@ nameDoc = ""
 
 ###########################################################
 
-def readmerge(name, lang = "", debug = False):
+def readmerge(name, dir, lang = "", debug = False):
     global phase
     global nameDoc
     nameDoc = name
-    app_folder = os.path.dirname(__file__)
+    app_folder = os.path.dirname(dir)
     fi = os.path.join(app_folder, "data")
     fo = os.path.join(app_folder, "output", "out_cropper")
     phase = 1

--- a/pySIC.py
+++ b/pySIC.py
@@ -15,7 +15,7 @@ def readmerge(name, lang = "", debug = False):
     global phase
     global nameDoc
     nameDoc = name
-    app_folder = os.path.dirname(os.getcwd())
+    app_folder = os.getcwd()
     fi = os.path.join(app_folder, "data")
     fo = os.path.join(app_folder, "output", "out_cropper")
     phase = 1
@@ -26,7 +26,7 @@ def elaborate(name, ocr = False, lang = "", debug = False):
     global phase
     global nameDoc
     nameDoc = name
-    app_folder = os.path.dirname(os.getcwd())
+    app_folder = os.getcwd()
     fi = os.path.join(app_folder, "data")
     fo = os.path.join(app_folder, "output", "out_cropper")
     phase = 1
@@ -48,7 +48,7 @@ def elaborate(name, ocr = False, lang = "", debug = False):
     
 def reset(delData = False, delPdf = {"general": False, "reader": False, "maker": False}):
     if delPdf["general"]:
-        dr = os.path.dirname(os.getcwd())
+        dr = os.getcwd()
         for d in os.listdir("."):
             if d.endswith(".pdf"):
                 os.remove(os.path.join(dr, d))

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(name='pySIC',
       author_email='davdag24@gmail.com',
       url='',
       license='MIT',
-      py_modules=['pySIC'],  
+      py_modules=['pySIC','reader','cropper','maker','merger'],  
       package_data={
       'pySIC.fonts': ['*'],
       }


### PR DESCRIPTION
La libreria non funzionava perchè non trovava i file reader,maker,cropper e merger; questi sono stati aggiunti al setup.py. Inoltre nel file pySIC ho cambiato il metodo di estrazione dell'attuale directory dato che quello precedente era ridondante e non funzionava con la libreria poichè cercava nella directory in cui si trovava la libreria.